### PR TITLE
point to Purescript by Example book

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * [Modules](#modules)
     * [Defining Modules](#defining-modules)
     * [Importing Modules](#importing-modules)
+* [Links](#links)
 
 ## Language Summary
 
@@ -330,3 +331,10 @@ import Data.List ((:))
 import MyModule (someFunction, someType(..), someType(Tag, AnotherTag), class SomeClass)
 -- For MyModule, only the function, types, and class mentioned are in scope
 ```
+
+## Links
+
+- [Purescript by Example](https://leanpub.com/purescript/read)
+- [egghead.io Tutorials](https://egghead.io/search?q=purescript)
+- [Purescript Search Engine](https://pursuit.purescript.org/)
+- [Purescript Docs](https://github.com/purescript/documentation)


### PR DESCRIPTION
There might be some other examples to point to, but the canonical "by example" book should probably be included somewhere.